### PR TITLE
Added new method to get the mobile friendly OAuth page instead of the desktop one

### DIFF
--- a/src/main/java/net/dean/jraw/http/oauth/OAuthHelper.java
+++ b/src/main/java/net/dean/jraw/http/oauth/OAuthHelper.java
@@ -73,7 +73,7 @@ public class OAuthHelper {
         HttpRequest r = new HttpRequest.Builder()
                 .https(true)
                 .host(RedditClient.HOST_SPECIAL)
-                .path("/api/v1/authorize.compact")
+                .path("/api/v1/authorize")
                 .expected(MediaTypes.HTML.type())
                 .query(JrawUtils.mapOf(
                         "client_id", creds.getClientId(),
@@ -107,7 +107,7 @@ public class OAuthHelper {
         HttpRequest r = new HttpRequest.Builder()
                 .https(true)
                 .host(RedditClient.HOST_SPECIAL)
-                .path("/api/v1/authorize")
+                .path("/api/v1/authorize.compact")
                 .expected(MediaTypes.HTML.type())
                 .query(JrawUtils.mapOf(
                         "client_id", creds.getClientId(),

--- a/src/test/java/net/dean/jraw/test/OAuthHelperTest.java
+++ b/src/test/java/net/dean/jraw/test/OAuthHelperTest.java
@@ -94,7 +94,7 @@ public class OAuthHelperTest {
                         "duration", "permanent",
                         "scope", "scope1 scope2"
                 ).build();
-        HttpRequest actual = HttpRequest.from("GET", helper.getAuthorizationUrl(
+        HttpRequest actual = HttpRequest.from("GET", helper.getAuthorizationUrlForMobile(
                 Credentials.webapp("myClientId", "", "http://www.example.com"), true, "scope1", "scope2"
         ));
 


### PR DESCRIPTION
I've been using this library on Android and I added in a method that would allow me to fetch the mobile friendly login form.

This is explained in the [Reddit API wiki](https://github.com/reddit/reddit/wiki/OAuth2):
Note: Use /api/v1/authorize.compact? for a page that's friendlier to small screens.

I tested this on my Nexus 6 and I was able to login using my username and password, authorize my app and get the response successfully.