### PR TITLE
Add null-check for response before variable is used

### DIFF
--- a/src/main/java/net/dean/jraw/http/CheckedNetworkException.java
+++ b/src/main/java/net/dean/jraw/http/CheckedNetworkException.java
@@ -11,12 +11,17 @@ public class CheckedNetworkException extends Exception {
     }
 
     public CheckedNetworkException(RestResponse response) {
-        super(String.format("Request returned non-successful status code: %s %s",
-                response.getStatusCode(),
-                response.getStatusMessage()));
+        super(getExceptionMessage(response));
+        this.response = response;
+    }
+
+    private static String getExceptionMessage(RestResponse response) {
         if (response == null)
             throw new NullPointerException("response cannot be null");
-        this.response = response;
+
+        return String.format("Request returned non-successful status code: %s %s",
+                response.getStatusCode(),
+                response.getStatusMessage());
     }
 
     public RestResponse getResponse() {

--- a/src/main/java/net/dean/jraw/http/NetworkException.java
+++ b/src/main/java/net/dean/jraw/http/NetworkException.java
@@ -14,12 +14,17 @@ public class NetworkException extends RuntimeException {
      * @param response The cause of this exception
      */
     public NetworkException(RestResponse response) {
-        super(String.format("Request returned non-successful status code: %s %s",
-                response.getStatusCode(),
-                response.getStatusMessage()));
+        super(getExceptionMessage(response));
+        this.response = response;
+    }
+
+    private static String getExceptionMessage(RestResponse response) {
         if (response == null)
             throw new NullPointerException("response cannot be null");
-        this.response = response;
+
+        return String.format("Request returned non-successful status code: %s %s",
+                response.getStatusCode(),
+                response.getStatusMessage());
     }
 
     public RestResponse getResponse() {


### PR DESCRIPTION
In the current constructor, response object is used before the null check for the parameter is performed.