### PR TITLE
Allow user to provide OkHttpClient instance

### DIFF
--- a/src/main/java/net/dean/jraw/http/OkHttpAdapter.java
+++ b/src/main/java/net/dean/jraw/http/OkHttpAdapter.java
@@ -32,7 +32,11 @@ public final class OkHttpAdapter implements HttpAdapter<OkHttpClient> {
     }
 
     public OkHttpAdapter(Protocol protocol) {
-        this.http = new OkHttpClient();
+        this(new OkHttpClient(), protocol);
+    }
+
+    public OkHttpAdapter(OkHttpClient httpClient, Protocol protocol) {
+        this.http = httpClient;
         this.cookieManager = new CookieManager(null, CookiePolicy.ACCEPT_ALL);
         this.defaultHeaders = new HashMap<>();
 


### PR DESCRIPTION
Useful if the user already has a configured instance that's used in the rest of the application. Especially nice if you use interceptors, so that you don't have to set things up again for the API client.