### PR TITLE
Add accumulateMergedAll() and accumulateMergedAllSorted() to UserSubredditsPaginator

### DIFF
--- a/src/main/java/net/dean/jraw/models/Subreddit.java
+++ b/src/main/java/net/dean/jraw/models/Subreddit.java
@@ -7,7 +7,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 
 /** This class represents a subreddit, such as /r/pics. */
 @Model(kind = Model.Kind.SUBREDDIT)
-public final class Subreddit extends Thing {
+public final class Subreddit extends Thing implements Comparable<Subreddit> {
 
     /** Instantiates a new Subreddit */
     public Subreddit(JsonNode dataNode) {
@@ -146,6 +146,12 @@ public final class Subreddit extends Thing {
     @JsonProperty
     public Boolean isUserSubscriber() {
         return data("user_is_subscriber", Boolean.class);
+    }
+
+
+    @Override
+    public int compareTo(Subreddit subreddit) {
+        return getDisplayName().compareTo(subreddit.getDisplayName());
     }
 
     /** This class represents a list of all the available subreddit types */

--- a/src/main/java/net/dean/jraw/paginators/UserSubredditsPaginator.java
+++ b/src/main/java/net/dean/jraw/paginators/UserSubredditsPaginator.java
@@ -3,8 +3,13 @@ package net.dean.jraw.paginators;
 import net.dean.jraw.EndpointImplementation;
 import net.dean.jraw.Endpoints;
 import net.dean.jraw.RedditClient;
+import net.dean.jraw.http.NetworkException;
 import net.dean.jraw.models.Listing;
 import net.dean.jraw.models.Subreddit;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 
 /**
  * This paginator provides a way to iterate through the logged-in user's subreddits they interact with, whether that be
@@ -42,5 +47,29 @@ public class UserSubredditsPaginator extends GenericPaginator<Subreddit> {
     public Listing<Subreddit> next(boolean forceNetwork) {
         // Just call super so that we can add the @EndpointImplementation annotation
         return super.next(forceNetwork);
+    }
+
+    /**
+     * Creates a flatten list that contains all the subreddits associated with the user
+     * @return A flatten list of subreddits
+     * @throws NetworkException
+     */
+    public final List<Subreddit> accumulateMergedAll() throws NetworkException {
+        // reset so that we start from the beginning
+        reset();
+        ArrayList<Subreddit> flattened = new ArrayList<>();
+
+        while (hasNext()){
+            flattened.addAll(next(true));
+        }
+
+        return flattened;
+    }
+
+    public final List<Subreddit> accumulateMergedAllSorted() throws NetworkException {
+        List<Subreddit> list = accumulateMergedAll();
+        Collections.sort(list);
+
+        return list;
     }
 }

--- a/src/test/java/net/dean/jraw/test/PaginationTest.java
+++ b/src/test/java/net/dean/jraw/test/PaginationTest.java
@@ -1,21 +1,18 @@
 package net.dean.jraw.test;
 
+import com.google.common.collect.Ordering;
 import net.dean.jraw.ApiException;
 import net.dean.jraw.JrawUtils;
 import net.dean.jraw.RedditClient;
 import net.dean.jraw.http.NetworkException;
 import net.dean.jraw.managers.MultiRedditManager;
-import net.dean.jraw.models.Listing;
-import net.dean.jraw.models.MultiReddit;
-import net.dean.jraw.models.Submission;
-import net.dean.jraw.models.Thing;
+import net.dean.jraw.models.*;
 import net.dean.jraw.paginators.*;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
-import java.util.Arrays;
-import java.util.Date;
-import java.util.List;
+import java.lang.reflect.Array;
+import java.util.*;
 
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
@@ -97,13 +94,27 @@ public class PaginationTest extends RedditTest {
     }
 
     @Test
-    public void testUserSubredditsPaginator() throws NetworkException {
+    public void testUserSubredditsPaginatorAccumulateMergedAll() throws NetworkException {
         String[] wheres = new UserSubredditsPaginator(reddit, "subscriber").getWhereValues();
         // Test all Where values
-
         for (String where : wheres) {
             UserSubredditsPaginator paginator = new UserSubredditsPaginator(reddit, where);
-            commonTest(paginator);
+            List<Subreddit> flatten = paginator.accumulateMergedAll();
+            for (int i = 0; i < flatten.size(); i++) {
+                Subreddit sub = flatten.get(i);
+                validateModel(sub);
+            }
+        }
+    }
+
+    @Test
+    public void testUserSubredditsPaginatorAccumulateMergedAllSorted() throws NetworkException {
+        String[] wheres = new UserSubredditsPaginator(reddit, "subscriber").getWhereValues();
+        for (String where : wheres) {
+            UserSubredditsPaginator paginator = new UserSubredditsPaginator(reddit, where);
+            List<Subreddit> flatten = paginator.accumulateMergedAllSorted();
+            boolean sorted = Ordering.natural().isOrdered(flatten);
+            Assert.assertEquals(sorted, true);
         }
     }
 


### PR DESCRIPTION
- accumulateMergedAll() is used to return all Subreddits a user has
- accumulateMergedAllSorted() is the same as accumulateMergedAll()
  except it is sorted

I wrote 2 convenient methods for `UserSubredditsPaginator`. I'm writing a reddit client and I need to list  down all the subreddits of a user. So I need to have a flatten lists of subreddit, while I can do this outside of this library, I think these methods are better to be here.

I didn't add these methods to `RedditIterable` where `accumulateMerged()` resides, because `RedditIterable` is shared by others, for example, `SubredditPaginator`, which can go on infinitely, so I think it only make sense to `UserSubredditsPaginator`.

Also, thanks for your library! Your code is neat and I learned a lot from trying to understand your code.