### PR TITLE
Fixed UserSubredditsPaginator#accumulateMergedAllSorted() to ignore case

### DIFF
--- a/src/main/java/net/dean/jraw/models/Subreddit.java
+++ b/src/main/java/net/dean/jraw/models/Subreddit.java
@@ -151,7 +151,7 @@ public final class Subreddit extends Thing implements Comparable<Subreddit> {
 
     @Override
     public int compareTo(Subreddit subreddit) {
-        return getDisplayName().compareTo(subreddit.getDisplayName());
+        return getDisplayName().compareToIgnoreCase(subreddit.getDisplayName());
     }
 
     /** This class represents a list of all the available subreddit types */

--- a/src/test/java/net/dean/jraw/test/PaginationTest.java
+++ b/src/test/java/net/dean/jraw/test/PaginationTest.java
@@ -12,6 +12,7 @@ import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import java.util.Arrays;
+import java.util.Comparator;
 import java.util.Date;
 import java.util.List;
 
@@ -113,7 +114,13 @@ public class PaginationTest extends RedditTest {
         for (String where : wheres) {
             UserSubredditsPaginator paginator = new UserSubredditsPaginator(reddit, where);
             List<Subreddit> flatten = paginator.accumulateMergedAllSorted();
-            boolean sorted = Ordering.natural().isOrdered(flatten);
+            boolean sorted = Ordering.from(new Comparator<Subreddit>() {
+                @Override
+                public int compare(Subreddit sub1, Subreddit sub2) {
+                    return sub1.getDisplayName().compareToIgnoreCase(sub2.getDisplayName());
+                }
+            }).isOrdered(flatten);
+
             Assert.assertEquals(sorted, true);
         }
     }


### PR DESCRIPTION
A minor fix to ignore case while doing comparison of subreddit names, because I realize users would prefer:

- Android
- androidapps
- androiddev
- bestof
- LifeProTips
- pics
- WritingPrompts

compared to:

- Android
- LifeProTips
- WritingPrompts
- androidapps
- androiddev
- bestof
- pics

