### PR TITLE
Fix get trophies for any username

### DIFF
--- a/src/main/java/net/dean/jraw/RedditClient.java
+++ b/src/main/java/net/dean/jraw/RedditClient.java
@@ -525,8 +525,7 @@ public class RedditClient extends RestClient {
     public List<Trophy> getTrophies(String username) throws NetworkException {
         if (username == null)
             assertNotUserless();
-        username = authenticatedUser;
-
+        
         RestResponse response = execute(request()
                 .endpoint(Endpoints.OAUTH_USER_USERNAME_TROPHIES, username)
                 .build());


### PR DESCRIPTION
It was always returning the trophies for the authenticated user.