### PR TITLE
Update to okhttp3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,9 @@ allprojects {
 }
 
 dependencies {
-    compile     'com.squareup.okhttp:okhttp:2.7.0'
+    def okHttpVersion = '3.1.1'
+    compile     "com.squareup.okhttp3:okhttp:$okHttpVersion"
+    compile     "com.squareup.okhttp3:okhttp-urlconnection:$okHttpVersion"
     compile     'com.fasterxml.jackson.core:jackson-databind:2.6.0'
     compile     'com.google.guava:guava:19.0'
     compile     'org.slf4j:slf4j-api:1.7.13'

--- a/src/main/java/net/dean/jraw/http/FormEncodedBodyBuilder.java
+++ b/src/main/java/net/dean/jraw/http/FormEncodedBodyBuilder.java
@@ -1,7 +1,7 @@
 package net.dean.jraw.http;
 
 import com.google.common.net.MediaType;
-import com.squareup.okhttp.internal.Util;
+import okhttp3.internal.Util;
 import net.dean.jraw.util.JrawUtils;
 
 import java.util.Map;

--- a/src/main/java/net/dean/jraw/http/HttpLogger.java
+++ b/src/main/java/net/dean/jraw/http/HttpLogger.java
@@ -1,6 +1,6 @@
 package net.dean.jraw.http;
 
-import com.squareup.okhttp.Headers;
+import okhttp3.Headers;
 import net.dean.jraw.util.JrawUtils;
 import okio.Buffer;
 import org.slf4j.Logger;

--- a/src/main/java/net/dean/jraw/http/HttpRequest.java
+++ b/src/main/java/net/dean/jraw/http/HttpRequest.java
@@ -1,10 +1,10 @@
 package net.dean.jraw.http;
 
 import com.google.common.net.MediaType;
-import com.squareup.okhttp.CacheControl;
-import com.squareup.okhttp.Headers;
-import com.squareup.okhttp.internal.Util;
-import com.squareup.okhttp.internal.http.HttpMethod;
+import okhttp3.CacheControl;
+import okhttp3.Headers;
+import okhttp3.internal.Util;
+import okhttp3.internal.http.HttpMethod;
 import net.dean.jraw.Endpoints;
 import net.dean.jraw.util.JrawUtils;
 

--- a/src/main/java/net/dean/jraw/http/RequestBody.java
+++ b/src/main/java/net/dean/jraw/http/RequestBody.java
@@ -1,7 +1,7 @@
 package net.dean.jraw.http;
 
 import com.google.common.net.MediaType;
-import com.squareup.okhttp.internal.Util;
+import okhttp3.internal.Util;
 import okio.BufferedSink;
 
 import java.io.IOException;

--- a/src/main/java/net/dean/jraw/http/RestClient.java
+++ b/src/main/java/net/dean/jraw/http/RestClient.java
@@ -1,7 +1,7 @@
 package net.dean.jraw.http;
 
 import com.google.common.util.concurrent.RateLimiter;
-import com.squareup.okhttp.Headers;
+import okhttp3.Headers;
 import net.dean.jraw.util.JrawUtils;
 
 import java.io.IOException;

--- a/src/main/java/net/dean/jraw/http/RestResponse.java
+++ b/src/main/java/net/dean/jraw/http/RestResponse.java
@@ -3,7 +3,7 @@ package net.dean.jraw.http;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.base.Charsets;
 import com.google.common.net.MediaType;
-import com.squareup.okhttp.Headers;
+import okhttp3.Headers;
 import net.dean.jraw.ApiException;
 import net.dean.jraw.util.JrawUtils;
 import net.dean.jraw.models.JsonModel;

--- a/src/main/java/net/dean/jraw/paginators/Paginator.java
+++ b/src/main/java/net/dean/jraw/paginators/Paginator.java
@@ -1,6 +1,6 @@
 package net.dean.jraw.paginators;
 
-import com.squareup.okhttp.CacheControl;
+import okhttp3.CacheControl;
 import net.dean.jraw.RedditClient;
 import net.dean.jraw.http.*;
 import net.dean.jraw.models.Listing;

--- a/src/main/java/net/dean/jraw/util/JrawUtils.java
+++ b/src/main/java/net/dean/jraw/util/JrawUtils.java
@@ -127,7 +127,7 @@ public final class JrawUtils {
     }
 
     /** Compares the type and subtype of two MediaTypes. Will recognize the asterisk ('*') as a wildcard. */
-    public static boolean isEqual(com.squareup.okhttp.MediaType t1, com.google.common.net.MediaType t2) {
+    public static boolean isEqual(okhttp3.MediaType t1, com.google.common.net.MediaType t2) {
         return isEqual(t1.type(), t1.subtype(), t2.type(), t2.subtype());
     }
 


### PR DESCRIPTION
Some breaking API changes, mainly around making each client immutable and requiring `newBuilder()` for future changes. Also requires `okhttp-urlconnection` for `JavaNetCookieJar`, which wraps `CookieManager` for their new `CookieJar` API.