### PR TITLE
Fixed sorting on non-submission paginators

### DIFF
--- a/src/main/java/net/dean/jraw/paginators/Paginator.java
+++ b/src/main/java/net/dean/jraw/paginators/Paginator.java
@@ -86,9 +86,14 @@ public abstract class Paginator<T extends Thing> implements RedditIterable<T> {
 
         String sorting = getSortingString();
         boolean sortingUsed = sorting != null;
-        if (sortingUsed && timePeriod != null) {
-            // Time period only applies to controversial and top listings
-            args.put("t", timePeriod.name().toLowerCase());
+
+        if (sortingUsed) {
+            args.put("sort", sorting);
+
+            if (timePeriod != null) {
+                // Time period only applies to controversial and top listings
+                args.put("t", timePeriod.name().toLowerCase());
+            }
         }
 
         Map<String, String> extraArgs = getExtraQueryArgs();


### PR DESCRIPTION
Fixes #124.

It adds the sort param directly in the Paginator. It makes sense since sort is used in listings. If a particular listing doesn't use sort, reddit will ignore it.