### PR TITLE
Fix lingering connections due to unclosed response body

### DIFF
--- a/src/main/java/net/dean/jraw/http/OkHttpAdapter.java
+++ b/src/main/java/net/dean/jraw/http/OkHttpAdapter.java
@@ -1,8 +1,5 @@
 package net.dean.jraw.http;
 
-import okhttp3.*;
-import okio.BufferedSink;
-
 import java.io.IOException;
 import java.net.CookieManager;
 import java.net.CookiePolicy;
@@ -12,6 +9,17 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
+
+import okhttp3.Authenticator;
+import okhttp3.Credentials;
+import okhttp3.JavaNetCookieJar;
+import okhttp3.MediaType;
+import okhttp3.OkHttpClient;
+import okhttp3.Protocol;
+import okhttp3.Request;
+import okhttp3.Response;
+import okhttp3.Route;
+import okio.BufferedSink;
 
 /**
  * Provides a concrete HttpAdapter implementation using Square's OkHttp
@@ -72,9 +80,8 @@ public final class OkHttpAdapter implements HttpAdapter<OkHttpClient> {
                 .headers(request.getHeaders());
 
         Response response = perRequestClient.newCall(builder.build()).execute();
-
         return new RestResponse(request,
-                response.body().source().inputStream(),
+                response.body().string(),
                 response.headers(),
                 response.code(),
                 response.message(),

--- a/src/main/java/net/dean/jraw/http/RestResponse.java
+++ b/src/main/java/net/dean/jraw/http/RestResponse.java
@@ -1,18 +1,16 @@
 package net.dean.jraw.http;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.google.common.base.Charsets;
 import com.google.common.net.MediaType;
-import okhttp3.Headers;
+
 import net.dean.jraw.ApiException;
-import net.dean.jraw.util.JrawUtils;
 import net.dean.jraw.models.JsonModel;
 import net.dean.jraw.models.Listing;
 import net.dean.jraw.models.RedditObject;
 import net.dean.jraw.models.meta.ModelManager;
+import net.dean.jraw.util.JrawUtils;
 
-import java.io.InputStream;
-import java.util.Scanner;
+import okhttp3.Headers;
 
 /**
  * This class is used to show the result of a request to a RESTful web service, such as Reddit's JSON API.
@@ -41,7 +39,7 @@ public class RestResponse {
      * Instantiates a new RedditResponse
      */
     @SuppressWarnings("ThrowableInstanceNeverThrown")
-    RestResponse(HttpRequest origin, InputStream body, Headers headers, int statusCode, String statusMessage, String protocol) {
+    RestResponse(HttpRequest origin, String body, Headers headers, int statusCode, String statusMessage, String protocol) {
         this.origin = origin;
         this.headers = headers;
         this.statusCode = statusCode;
@@ -53,8 +51,7 @@ public class RestResponse {
             if (contentType == null)
                 throw new IllegalStateException("No Content-Type header was found");
             this.type = JrawUtils.parseMediaType(contentType);
-            String charset = type.charset().or(Charsets.UTF_8).name();
-            this.raw = readContent(body, charset);
+            this.raw = body;
 
             // Assume there aren't any exceptions
             ApiException error = null;
@@ -85,16 +82,6 @@ public class RestResponse {
             this.raw = null;
             this.rootNode = null;
             this.apiException = null;
-        }
-    }
-
-    private String readContent(InputStream entity, String charset) {
-        try {
-            Scanner s = new Scanner(entity, charset).useDelimiter("\\A");
-            return s.hasNext() ? s.next() : "";
-        } catch (Exception e) {
-            JrawUtils.logger().error("Could not read the body of the given response");
-            throw e;
         }
     }
 


### PR DESCRIPTION
* response.body() were not closed as required by OkHTTP to close connections.
  response.body().string() calls close(), which fixes the issue
  Will get rid of log messages such as: "A connection to https://oauth.reddit.com/ was leaked.
  Did you forget to close a response body?"