### PR TITLE
Preventing a null-pointer exception and adding redirect url parameter

### DIFF
--- a/src/main/java/net/dean/jraw/http/oauth/Credentials.java
+++ b/src/main/java/net/dean/jraw/http/oauth/Credentials.java
@@ -118,6 +118,21 @@ public final class Credentials {
 
     /**
      * Creates a new Credentials object for a Reddit app whose type is 'web app.' All parameters must be non-null.
+     *
+     * @param username The app owner's username
+     * @param password The app owner's password
+     * @param clientId The publicly-available app ID
+     * @param clientSecret The secret value for the application
+     * @param redirectUrl The url to be redirected to
+     * @return A new Credentials
+     */
+    public static Credentials script(String username, String password, String clientId, String clientSecret, String redirectUrl) {
+        assertNotNull(username, password, clientId, clientSecret);
+        return new Credentials(AuthenticationMethod.SCRIPT, username, password, clientId, clientSecret, redirectUrl);
+    }
+
+    /**
+     * Creates a new Credentials object for a Reddit app whose type is 'web app.' All parameters must be non-null.
      * @param clientId The publicly-available app ID
      * @param clientSecret The secret value for the application
      * @return A new Credentials

--- a/src/main/java/net/dean/jraw/http/oauth/OAuthHelper.java
+++ b/src/main/java/net/dean/jraw/http/oauth/OAuthHelper.java
@@ -83,6 +83,12 @@ public class OAuthHelper {
         String urlPath = "/api/v1/authorize";
         if (useMobileSite) urlPath += ".compact";
 
+        URL url = creds.getRedirectUrl();
+        String extenalForm = "";
+        if(url != null){
+            extenalForm = url.toExternalForm();
+        }
+
         HttpRequest r = new HttpRequest.Builder()
                 .https(true)
                 .host(RedditClient.HOST_SPECIAL)
@@ -92,7 +98,7 @@ public class OAuthHelper {
                         "client_id", creds.getClientId(),
                         "response_type", "code",
                         "state", state,
-                        "redirect_uri", creds.getRedirectUrl().toExternalForm(),
+                        "redirect_uri", extenalForm,
                         "duration", permanent ? "permanent" : "temporary",
                         "scope", JrawUtils.join(' ', scopes)
                 )).build();

--- a/src/main/java/net/dean/jraw/managers/LiveThreadManager.java
+++ b/src/main/java/net/dean/jraw/managers/LiveThreadManager.java
@@ -113,6 +113,7 @@ public class LiveThreadManager extends AbstractManager {
                 .build());
     }
 
+    /** Strikes an update so that it will appear <del>like this</del> on the website. */
     @EndpointImplementation(Endpoints.LIVE_THREAD_STRIKE_UPDATE)
     public void strikeUpdate(LiveThread host, LiveUpdate update) throws ApiException {
         genericPost(reddit.request()

--- a/src/main/java/net/dean/jraw/managers/LiveThreadManager.java
+++ b/src/main/java/net/dean/jraw/managers/LiveThreadManager.java
@@ -113,7 +113,6 @@ public class LiveThreadManager extends AbstractManager {
                 .build());
     }
 
-    /** Strikes an update so that it will appear <del>like this</del> on the website. */
     @EndpointImplementation(Endpoints.LIVE_THREAD_STRIKE_UPDATE)
     public void strikeUpdate(LiveThread host, LiveUpdate update) throws ApiException {
         genericPost(reddit.request()


### PR DESCRIPTION
I have been working to create a script client and I have found that the redirect url has to be set anyway.

When not set, it should not cause a null-pointer exception.