### PR TITLE
Fixed bad request for multireddits with sorting

### DIFF
--- a/src/main/java/net/dean/jraw/paginators/MultiRedditPaginator.java
+++ b/src/main/java/net/dean/jraw/paginators/MultiRedditPaginator.java
@@ -23,8 +23,8 @@ public class MultiRedditPaginator extends Paginator<Submission> {
 
     @Override
     protected String getBaseUri() {
-        String path = sorting == null ? "" : "/" + sorting.name().toLowerCase();
-        return multiReddit.getPath() + path;
+        String sort = sorting == null ? "" : sorting.name().toLowerCase();
+        return multiReddit.getPath() + sort;
     }
 
     /**


### PR DESCRIPTION
multireddit.getPath() includes a trailing slash, so one does not need to be appended, requests were coming back as 400 bad request due to the `//` in the path
