### PR TITLE
FIX: correctly calculate if refresh token is expired

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 *.iml
 *.ipr
 *.iws
+local.properties
 
 # Gradle
 .gradle/

--- a/src/main/java/net/dean/jraw/RedditClient.java
+++ b/src/main/java/net/dean/jraw/RedditClient.java
@@ -98,7 +98,7 @@ public class RedditClient extends RestClient {
         if (authData.getAuthenticationMethod() == null ||
                 authData.getScopes() == null ||
                 authData.getAccessToken() == null ||
-                authData.getExpirationDate() == null)
+                authData.getExpirationDurationMillis() == null)
             throw new NullPointerException("Missing important data from OAuth JSON: " + authData.getDataNode());
 
         this.authMethod = authData.getAuthenticationMethod();

--- a/src/main/java/net/dean/jraw/auth/ApatheticTokenStore.java
+++ b/src/main/java/net/dean/jraw/auth/ApatheticTokenStore.java
@@ -13,10 +13,23 @@ public final class ApatheticTokenStore implements TokenStore {
     }
 
     @Override
+    public boolean isAcquiredTimeStored(String key) {
+        return false;
+    }
+
+    @Override
     public String readToken(String key) throws NoSuchTokenException {
         throw new NoSuchTokenException("TokenStore is apathetic");
     }
 
     @Override
     public void writeToken(String key, String token) {}
+
+    @Override
+    public long readAcquireTimeMillis(String key) {
+        throw new UnsupportedOperationException("TokenStore is apathetic");
+    }
+
+    @Override
+    public void writeAcquireTimeMillis(String key, long acquireTimeMs) {}
 }

--- a/src/main/java/net/dean/jraw/auth/RefreshTokenHandler.java
+++ b/src/main/java/net/dean/jraw/auth/RefreshTokenHandler.java
@@ -45,6 +45,11 @@ public final class RefreshTokenHandler implements TokenStore {
     }
 
     @Override
+    public boolean isAcquiredTimeStored(String username) {
+        return store.isAcquiredTimeStored(getKeyFor(username)) || isClientValidSource(username);
+    }
+
+    @Override
     public String readToken(String username) throws NoSuchTokenException {
         if (reddit.getOAuthData() == null)
             return store.readToken(getKeyFor(username));
@@ -57,6 +62,16 @@ public final class RefreshTokenHandler implements TokenStore {
     public void writeToken(String username, String token) {
         store.writeToken(getKeyFor(username), token);
         store.writeToken(KEY_LAST_USER, username);
+    }
+
+    @Override
+    public long readAcquireTimeMillis(String username) {
+        return store.readAcquireTimeMillis(getKeyFor(username));
+    }
+
+    @Override
+    public void writeAcquireTimeMillis(String username, long acquireTimeMs) {
+        store.writeAcquireTimeMillis(getKeyFor(username), acquireTimeMs);
     }
 
     /**

--- a/src/main/java/net/dean/jraw/auth/TokenStore.java
+++ b/src/main/java/net/dean/jraw/auth/TokenStore.java
@@ -8,6 +8,9 @@ public interface TokenStore {
     /** Checks if a token is already stored */
     boolean isStored(String key);
 
+    /** Checks if a token's acquire time is stored. */
+    boolean isAcquiredTimeStored(String key);
+
     /**
      * Gets a token. If none is found, then a {@link NoSuchTokenException} is thrown
      * @throws NoSuchTokenException If the given key does not have a value
@@ -16,4 +19,8 @@ public interface TokenStore {
 
     /** Writes a token. */
     void writeToken(String key, String token);
+
+    long readAcquireTimeMillis(String key);
+
+    void writeAcquireTimeMillis(String key, long acquireTimeMs);
 }

--- a/src/main/java/net/dean/jraw/auth/VolatileTokenStore.java
+++ b/src/main/java/net/dean/jraw/auth/VolatileTokenStore.java
@@ -5,20 +5,36 @@ import java.util.Map;
 
 /** Simple TokenStore that uses a Map. Does not persist data. */
 public class VolatileTokenStore implements TokenStore {
-    private final Map<String, String> map = new HashMap<>();
+    private final Map<String, String> tokenMap = new HashMap<>();
+    private final Map<String, Long> acquireTimeMap = new HashMap<>();
 
     @Override
     public boolean isStored(String key) {
-        return map.containsKey(key);
+        return tokenMap.containsKey(key);
+    }
+
+    @Override
+    public boolean isAcquiredTimeStored(String key) {
+        return acquireTimeMap.containsKey(key);
     }
 
     @Override
     public String readToken(String key) throws NoSuchTokenException {
-        return map.get(key);
+        return tokenMap.get(key);
     }
 
     @Override
     public void writeToken(String key, String token) {
-        map.put(key, token);
+        tokenMap.put(key, token);
+    }
+
+    @Override
+    public long readAcquireTimeMillis(String key) {
+        return acquireTimeMap.get(key);
+    }
+
+    @Override
+    public void writeAcquireTimeMillis(String key, long acquireTimeMs) {
+        acquireTimeMap.put(key, acquireTimeMs);
     }
 }

--- a/src/main/java/net/dean/jraw/http/oauth/OAuthData.java
+++ b/src/main/java/net/dean/jraw/http/oauth/OAuthData.java
@@ -1,11 +1,10 @@
 package net.dean.jraw.http.oauth;
 
+import com.fasterxml.jackson.databind.JsonNode;
+
 import net.dean.jraw.http.AuthenticationMethod;
 import net.dean.jraw.models.JsonModel;
 import net.dean.jraw.models.meta.JsonProperty;
-import com.fasterxml.jackson.databind.JsonNode;
-
-import java.util.Date;
 
 /**
  * This class represents the data provided from a successful request to {@code /api/v1/access_token}. See
@@ -42,11 +41,8 @@ public class OAuthData extends JsonModel {
      * Gets the date at which the access token expires, which will be in one hour from when it was originally requested.
      */
     @JsonProperty
-    public Date getExpirationDate() {
-        Date tokenExpiration = new Date();
-        // Add the time the token expires
-        tokenExpiration.setTime(tokenExpiration.getTime() + data("expires_in", Integer.class) * 1000);
-        return tokenExpiration;
+    public Long getExpirationDurationMillis() {
+        return data("expires_in", Long.class) * 1000;
     }
 
     /**


### PR DESCRIPTION
This fixes https://github.com/thatJavaNerd/JRAW/issues/179

@thatJavaNerd I'm slightly concerned about migration of clients because this introduces a new field to be stored along with access tokens in SharedPreferences. 

Update: ugh, I forgot to run the tests. I will do this tomorrow.